### PR TITLE
Fix Elm version in elm.json

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,7 +7,7 @@
     "exposed-modules": [
         "GroupList"
     ],
-    "elm-version": "0.17.1 <= v <= 0.19.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0"
     },


### PR DESCRIPTION
You had an invalid Elm version range in your elm.json file. The compiler unfortunately doesn't check for this but it should always be `"0.19.0 <= v < 0.20.0"`.